### PR TITLE
Add verbose parameter to CatelogController get_catalog method

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can install this package via PIP
 
 ## How to Build
 
-You must have Python 2 >=2.7.9 or Python 3 >=3.4 installed on your system to install and run this SDK. This SDK package depends on other Python packages like nose, jsonpickle etc. 
+You must have Python 2 >=2.7.9 or Python 3 >=3.4 installed on your system to install and run this SDK. This SDK package depends on other Python packages like nose, jsonpickle etc.
 These dependencies are defined in the ```requirements.txt``` file that comes with the SDK.
 To resolve these dependencies, you can use the PIP Dependency manager. Install it by following steps at [https://pip.pypa.io/en/stable/installing/](https://pip.pypa.io/en/stable/installing/).
 
@@ -46,7 +46,7 @@ Create a new directory by right clicking on the solution name as shown below:
 Name the directory as "test"
 
 ![Add a new project in PyCharm - Step 2](https://apidocs.io/illustration/python?step=nameDirectory)
-   
+
 Add a python file to this project with the name "testsdk"
 
 ![Add a new project in PyCharm - Step 3](https://apidocs.io/illustration/python?step=createFile&workspaceFolder=RaaSV2-Python&projectName=raas_v2)
@@ -391,8 +391,15 @@ An instance of the ``` CatalogController ``` class can be accessed from the API 
 > Get Catalog
 
 ```python
-def get_catalog(self)
+def get_catalog(self,
+                   verbose=True)
 ```
+
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| verbose |  ``` Optional ```  | Verbose Payload |
 
 #### Example Usage
 
@@ -446,7 +453,7 @@ An instance of the ``` StatusController ``` class can be accessed from the API C
 
 #### <a name="get_system_status"></a>![Method: ](https://apidocs.io/img/method.png ".StatusController.get_system_status") get_system_status
 
-> *Tags:*  ``` Skips Authentication ``` 
+> *Tags:*  ``` Skips Authentication ```
 
 > Retrieve system status
 
@@ -547,6 +554,3 @@ result = customers_client.get_all_customers()
 
 
 [Back to List of Controllers](#list_of_controllers)
-
-
-

--- a/raas_v2/controllers/catalog_controller.py
+++ b/raas_v2/controllers/catalog_controller.py
@@ -21,20 +21,13 @@ class CatalogController(BaseController):
         super(CatalogController, self).__init__(client, call_back)
         self.logger = logging.getLogger(__name__)
 
-    def get_catalog(self, options=dict()):
+    def get_catalog(self, verbose=True):
         """Does a GET request to /catalogs.
 
         Get Catalog
 
         Args:
-            options (dict, optional): Key-value pairs for any of the
-                parameters to this API Endpoint. All parameters to the
-                endpoint are supplied through the dictionary with their names
-                being the key and their desired values being the value. A list
-                of parameters that can be used are::
-
-                    verbose -- bool -- TODO: type description
-                        here.
+            verbose (bool, optional): Verbose Payload
 
         Returns:
             CatalogModel: Response from the API.
@@ -55,7 +48,7 @@ class CatalogController(BaseController):
             _query_builder += '/catalogs'
             _query_url = APIHelper.clean_url(_query_builder)
             _query_parameters = {
-                'verbose': options.get('verbose', True),
+                'verbose': verbose,
             }
 
             # Prepare headers

--- a/raas_v2/controllers/catalog_controller.py
+++ b/raas_v2/controllers/catalog_controller.py
@@ -21,13 +21,23 @@ class CatalogController(BaseController):
         super(CatalogController, self).__init__(client, call_back)
         self.logger = logging.getLogger(__name__)
 
-    def get_catalog(self):
+    def get_catalog(self, options=dict()):
         """Does a GET request to /catalogs.
 
         Get Catalog
 
+        Args:
+            options (dict, optional): Key-value pairs for any of the
+                parameters to this API Endpoint. All parameters to the
+                endpoint are supplied through the dictionary with their names
+                being the key and their desired values being the value. A list
+                of parameters that can be used are::
+
+                    verbose -- bool -- TODO: type description
+                        here.
+
         Returns:
-            CatalogModel: Response from the API. 
+            CatalogModel: Response from the API.
 
         Raises:
             APIException: When an error occurs while fetching the data from
@@ -38,26 +48,29 @@ class CatalogController(BaseController):
         """
         try:
             self.logger.info('get_catalog called.')
-    
+
             # Prepare query URL
             self.logger.info('Preparing query URL for get_catalog.')
             _query_builder = Configuration.get_base_uri()
             _query_builder += '/catalogs'
             _query_url = APIHelper.clean_url(_query_builder)
-    
+            _query_parameters = {
+                'verbose': options.get('verbose', True),
+            }
+
             # Prepare headers
             self.logger.info('Preparing headers for get_catalog.')
             _headers = {
                 'accept': 'application/json'
             }
-    
+
             # Prepare and execute request
             self.logger.info('Preparing and executing request for get_catalog.')
-            _request = self.http_client.get(_query_url, headers=_headers)
+            _request = self.http_client.get(_query_url, headers=_headers, query_parameters=_query_parameters)
             BasicAuth.apply(_request)
             _context = self.execute_request(_request, name = 'get_catalog')
             self.validate_response(_context)
-    
+
             # Return appropriate type
             return APIHelper.json_deserialize(_context.response.raw_body, CatalogModel.from_dictionary)
 


### PR DESCRIPTION
The `verbose` option on the `/catalogs` endpoint was not accounted for. Added a parameter to include verbose if desired. Defaults to `True`.